### PR TITLE
Implementation of Slideshows in 2.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,6 +77,8 @@
     'dcf-lazyLoad.js',
     'dcf-modal.js',
     'dcf-tabs.js',
+    'dcf-slideshow.js',
+    'dcf-slideshow-theme.js',
     'dcf-utility.js'  // Always include due to dependency with of some modules
   ]
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,6 @@
     'dcf-modal.js',
     'dcf-tabs.js',
     'dcf-slideshow.js',
-    'dcf-slideshow-theme.js',
     'dcf-utility.js'  // Always include due to dependency with of some modules
   ]
 

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
               <li>
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
-                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/111024-autumn-018-xl-min.jpg" alt="">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
                     <!--
                                       <img
                                         class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
@@ -227,7 +227,7 @@
               <li>
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
-                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/120424-campus-097-xl-min.jpg" alt="">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
                     <!--
                                       <img
                                         class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
@@ -245,7 +245,7 @@
               <!--Slide 3 with no figcaption-->
               <li>
                 <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
-                  <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
+                  <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
                   <!--
                                   <img
                                     class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
@@ -270,7 +270,7 @@
               <li>
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
-                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/111024-autumn-018-xl-min.jpg" alt="">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
                     <!--
                                       <img
                                         class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
@@ -289,7 +289,7 @@
               <li>
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
-                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/120424-campus-097-xl-min.jpg" alt="">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
                     <!--
                                       <img
                                         class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
@@ -307,7 +307,7 @@
               <!--Slide 3 with no figcaption-->
               <li>
                 <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
-                  <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
+                  <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
                   <!--
                                   <img
                                     class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
@@ -389,6 +389,18 @@
     const tabGroups = document.querySelectorAll('.dcf-tabs');
     const tabGroup = new DCFTabs(tabGroups);
     tabGroup.initialize();
+
+    // Slideshow Example
+    const openCaptionEvent = new Event('openCaption');
+    const closeCaptionEvent = new Event('closeCaption');
+    const slideshows = document.querySelectorAll('.dcf-slideshow');
+    const uls = document.querySelectorAll('.dcf-slideshow ul');
+
+    const slideshow = new DCFSlideshow(slideshows, uls, openCaptionEvent, closeCaptionEvent);
+    const slideshowTheme = new DCFSlideshowTheme(slideshows, openCaptionEvent, closeCaptionEvent);
+
+    slideshow.initialize();
+    slideshowTheme.initialize();
 
     // Lazy Load Example
     const images = document.querySelectorAll('[loading=lazy], .dcf-lazy-load');

--- a/index.html
+++ b/index.html
@@ -17,6 +17,149 @@
     Header markup here
   </header>
   <main class="dcf-wrapper" id="dcf-main" tabindex="-1" role="main">
+    <!-- Slideshow WIP -->
+    <style>
+      .dcf-slideshow ul {
+        margin-bottom: 0;
+        padding-left: 0; /* Remove broswer default padding for list */
+      }
+      .dcf-slideshow li {
+        margin-bottom: 0;
+      }
+      .dcf-slideshow ul:first-child {
+        display: flex;
+        list-style: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E");
+        overflow-x: scroll;
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+      }
+      .dcf-slideshow ul:first-child li {
+        scroll-snap-align: start;
+      }
+      .dcf-slideshow ul:first-child li:not(:last-child) {
+        margin-right: .75em; /* Create variable for this */
+      }
+      /* Fallback styles */
+      .dcf-slideshow ul:first-child li {
+        flex: 0 0 84%; /* Make sure some of the next slide appears */
+      }
+      /* Styles after JavaScript loads */
+      .dcf-slideshow ul:first-child li.dcf-slide {
+        flex: 0 0 100%; /* Make each slide fill the full width of the slideshow */
+      }
+      /* Theme styles */
+      /*
+          .unl .dcf-btn-slide-caption[aria-expanded="false"] svg {
+            transform: rotate(0);
+            transition: transform .2s cubic-bezier(.17,.89,.32,1.27);
+          }
+          .unl .dcf-btn-slide-caption[aria-expanded="true"] svg {
+            transform: rotate(45deg);
+            transition: transform .2s cubic-bezier(.17,.89,.32,1.27);
+          }
+      */
+      .unl .dcf-slide-caption[aria-hidden="true"] {
+        opacity: 0;
+        pointer-events: none;
+        /*   transition: opacity $timing-fade-out $easing-fade-out; */
+        transition: all 250ms ease-out;
+      }
+      .unl .dcf-slide-caption[aria-hidden="false"] {
+        opacity: 1;
+        pointer-events: auto;
+        /*   transition: opacity $timing-fade-in $easing-fade-in; */
+        transition: opacity 250ms ease-out;
+      }
+      .unl .dcf-slide-deck {
+        --btn-b-width: 2px;
+        --btn-size-x: 2.75rem;
+        --btn-size-y: 2.25rem;
+        --clip: 3px;
+        /*   clip-path: polygon(100% 0px, 100% calc(100% - 2.25em - 7px), calc(100% - 5.125em - 13px) calc(100% - 2.25em - 7px), calc(100% - 5.125em - 13px) 100%, 0px 100%, 0px 0px); */
+        /*
+          clip-path: polygon(
+            100% 0px,
+            100% calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
+            calc(100% - (var(--btn-size-x) * 2) - (var(--btn-b-width) * 5) - var(--clip)) calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
+            calc(100% - (var(--btn-size-x) * 2) - (var(--btn-b-width) * 5) - var(--clip)) 100%,
+            -(var(--clip)) 100%,
+            0px 0px
+          );
+        */
+        clip-path: polygon(
+                100% 0px,
+                100% calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
+                calc(100% - (var(--btn-size-x) * 2) - (var(--btn-b-width) * 5) - var(--clip)) calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
+                calc(100% - (var(--btn-size-x) * 2) - (var(--btn-b-width) * 5) - var(--clip)) 100%,
+                calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip)) 100%,
+                calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip)) calc(100% + var(--clip)),
+                -3px calc(100% + var(--clip)),
+                -3px calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
+                0px calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
+                0px 0px
+        );
+      }
+      .unl .dcf-slide-figure > div,
+      .unl .dcf-slide-figure figcaption {
+        /*   clip-path: polygon(100% 0px, 100% 100%, calc(2.56em + 7px) 100%, calc(2.56em + 7px) calc(100% - 2.25em - 7px), 0px calc(100% - 2.25em - 7px), 0px calc(100% - 2.25em - 4px), calc(2.56em + 4px) calc(100% - 2.25em - 4px), calc(2.56em + 4px) 100%, 0 100%, 0px 0px); */
+        /*
+                  clip-path: polygon(
+                          100% 0px,
+                          100% 100%,
+                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip) - 1px) 100%,
+                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip) - 1px) calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip) + 1px),
+                          0px calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip) + 1px), 0px calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) + 1px),
+                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) - 1px) calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) + 1px),
+                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) - 1px) 100%,
+                          0 100%,
+                          0px 0px
+                  );
+        */
+      }
+      .unl .dcf-btn-slide-caption {
+        background-color:rgba(36,36,35,.75);
+        border-color: transparent;
+        bottom: var(--clip);
+        left: var(--clip);
+        position: absolute;
+        z-index: 1;
+      }
+      .unl .dcf-slide-caption {
+        background-color: rgba(36,36,35,.75);
+        /*   clip-path: polygon(100% 0px, 100% 100%, calc(2.56rem + 7px) 100%, calc(2.56rem + 7px) calc(100% - 2.25rem - 7px), 0px calc(100% - 2.25rem - 7px), 0px 0px); */
+        /*
+              clip-path: polygon(
+                100% 0px,
+                100% 100%,
+                calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip)) 100%,
+                calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip)) calc(100% - var(--btn-size) - (var(--btn-p-y) * 2) - (var(--btn-b-width) * 2) - var(--clip)),
+                0px calc(100% - var(--btn-size) - (var(--btn-p-y) * 2) - (var(--btn-b-width) * 2) - var(--clip)),
+                0px 0px
+              );
+        */
+        clip-path: polygon(100% 0px, 100% 100%, calc((var(--clip) * 2) + (var(--btn-b-width) * 2) + var(--btn-size-x)) 100%, calc((var(--clip) * 2) + (var(--btn-b-width) * 2) + var(--btn-size-x)) calc(100% - (var(--clip) * 2) - (var(--btn-b-width) * 2) - var(--btn-size-y)), 0px calc(100% - (var(--clip) * 2) - (var(--btn-b-width) * 2) - var(--btn-size-y)), 0px 0px);
+        color: #fefdfa;
+        height: 100%;
+        left: 0;
+        padding: 1em 1.13em;
+        position: absolute;
+        top: 0;
+        width: 100%;
+        z-index: 1;
+      }
+      .dcf-btn-slide-caption[aria-expanded="false"] .unl-icon-slide-caption-open {
+        opacity: 1;
+        transition: opacity 250ms ease-out 125ms;
+      }
+      .dcf-btn-slide-caption[aria-expanded="true"] .unl-icon-slide-caption-open {
+        opacity: 0;
+        transition: opacity 250ms ease-out;
+      }
+      /* Temp until DCF is updated */
+      .dcf-btn-group li:not(:first-child) .dcf-btn-primary {
+        margin-left: 2px;
+      }
+    </style>
 
     <div class="dcf-bleed dcf-wrapper dcf-pt-9 dcf-pb-9">
       <div class="dcf-tabs">

--- a/index.html
+++ b/index.html
@@ -339,10 +339,10 @@
     const uls = document.querySelectorAll('.dcf-slideshow ul');
 
     const slideshow = new DCFSlideshow(slideshows, uls, openCaptionEvent, closeCaptionEvent);
-    const slideshowTheme = new DCFSlideshowTheme(slideshows, openCaptionEvent, closeCaptionEvent);
+    // const slideshowTheme = new DCFSlideshowTheme(slideshows, openCaptionEvent, closeCaptionEvent);
 
     slideshow.initialize();
-    slideshowTheme.initialize();
+    // slideshowTheme.initialize();
 
     // Lazy Load Example
     const images = document.querySelectorAll('[loading=lazy], .dcf-lazy-load');
@@ -360,7 +360,120 @@
 
     // JavaScript Support Example
     DCFUtility.flagSupportsJavaScript();
-    </script>
+
+    const keyframesClose1 = [
+      {
+        transform: 'rotate(45deg)',
+        transformOrigin: '50% 50%'
+      },
+      {
+        transform: 'rotate(0deg)',
+        transformOrigin: '50% 50%'
+      }
+    ];
+    const keyframesClose2 = [
+      {
+        transform: 'rotate(-45deg)',
+        transformOrigin: '50% 50%'
+      },
+      {
+        transform: 'rotate(0deg)',
+        transformOrigin: '50% 50%'
+      }
+    ];
+    const keyframesOpen1 = [
+      {
+        transform: 'rotate(0deg)',
+        transformOrigin: '50% 50%'
+      },
+      {
+        transform: 'rotate(45deg)',
+        transformOrigin: '50% 50%'
+      }
+    ];
+    const keyframesOpen2 = [
+      {
+        transform: 'rotate(0deg)',
+        transformOrigin: '50% 50%'
+      },
+      {
+        transform: 'rotate(-45deg)',
+        transformOrigin: '50% 50%'
+      }
+    ];
+    const options = {
+      duration: 250,
+      fill: 'forwards'
+    };
+
+    Array.prototype.forEach.call(slideshows, (slideshow) => {
+      // Slideshow Controls
+      let ctrlGroup = slideshow.querySelector('[aria-label = "slideshow controls"]'); // DCF
+      let ctrls = ctrlGroup.querySelectorAll('li');
+
+      Array.prototype.forEach.call(ctrls, (ctrl) => {
+        if (ctrl.getAttribute('id') === 'previous') {
+          let ctrlButton = ctrl.querySelector('button');
+          ctrlButton.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'unl-cream');
+          ctrlButton.innerHTML =
+                  '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">' +
+                  '<path d="M21.746.064a.504.504 0 0 0-.504.008l-19 11.5a.499.499 0 0 0-.001.856l19' +
+                  ' 11.5A.501.501 0 0 0 22 23.5V.5a.5.5 0 0 0-.254-.436z"></path>' +
+                  '</svg>';
+        } else if (ctrl.getAttribute('id') === 'next') {
+          let ctrlButton = ctrl.querySelector('button');
+          ctrlButton.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'unl-cream');
+          ctrlButton.innerHTML =
+                  '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">' +
+                  '<path d="M21.759 11.577L2.786.077a.499.499 0 0 0-.759.428v23a.498.498 ' +
+                  '0 0 0 .5.5c.09 0 .18-.024.259-.072l18.973-11.5a.5.5 0 0 0 0-.856z"></path>' +
+                  '</svg>';
+        }
+      });
+      // Caption Button
+      let figures = slideshow.querySelectorAll('.dcf-slideshow figure');
+      Array.prototype.forEach.call(figures, (figure) => {
+        let captionBtn = figure.querySelector('button');
+        if (!(typeof captionBtn === 'undefined')) {
+          captionBtn.innerHTML = '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" ' +
+                  'width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">' +
+                  '<path class="unl-icon-slide-caption-open" ' +
+                  'd="M1,3h19c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1C0.4,1,0,1.4,0,2C0,2.6,0.4,3,1,3z"/>' +
+                  '<path class="unl-icon-slide-caption-open" ' +
+                  'd="M1,8h15c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1C0.4,6,0,6.4,0,7C0,7.6,0.4,8,1,8z"/>' +
+                  '<path class="unl-icon-slide-caption-close-1" ' +
+                  'd="M1,13h22c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,12.6,0.4,13,1,13z"/>' +
+                  '<path class="unl-icon-slide-caption-close-2" ' +
+                  'd="M1,13h22c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,12.6,0.4,13,1,13z"/>' +
+                  '<path class="unl-icon-slide-caption-open" ' +
+                  'd="M1,18h18c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,17.6,0.4,18,1,18z"/>' +
+                  '<path class="unl-icon-slide-caption-open" ' +
+                  'd="M1,23h15c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,22.6,0.4,23,1,23z"/>' +
+                  '</svg>';
+        }
+      });
+    });
+    let slideBtns = document.querySelectorAll('.dcf-btn-slide');
+    Array.prototype.forEach.call(slideBtns, (slideBtn) => {
+      slideBtn.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'unl-cream');
+    });
+    let buttons = document.querySelectorAll('.dcf-btn-slide-caption');
+    Array.prototype.forEach.call(buttons, (button) => {
+      let caption = button.previousElementSibling;
+      let close1 = button.querySelector('.unl-icon-slide-caption-close-1');
+      let close2 = button.querySelector('.unl-icon-slide-caption-close-2');
+
+      caption.addEventListener('openCaption', () => {
+        close1.animate(keyframesClose1, options);
+        close2.animate(keyframesClose2, options);
+      }, false);
+
+      caption.addEventListener('closeCaption', () => {
+        close1.animate(keyframesOpen1, options);
+        close2.animate(keyframesOpen2, options);
+      }, false);
+    });
+  </script>
 
   </main>
   <footer class="dcf-footer" id="dcf-footer">

--- a/index.html
+++ b/index.html
@@ -209,16 +209,6 @@
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
                     <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
-                    <!--
-                                      <img
-                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
-                                        data-src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg"
-                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
-                                        alt="Placeholder photo">
-                                      <noscript>
-                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg" alt="">
-                                      </noscript>
-                    -->
                   </div>
                   <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
                 </figure>
@@ -228,16 +218,7 @@
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
                     <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
-                    <!--
-                                      <img
-                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
-                                        data-src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg"
-                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
-                                        alt="Placeholder photo">
-                                      <noscript>
-                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg" alt="">
-                                      </noscript>
-                    -->
+
                   </div>
                   <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
                 </figure>
@@ -246,16 +227,6 @@
               <li>
                 <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
                   <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
-                  <!--
-                                  <img
-                                    class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
-                                    data-src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg"
-                                    src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
-                                    alt="">
-                                  <noscript>
-                                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
-                                  </noscript>
-                  -->
                 </div>
               </li>
             </ul>
@@ -271,16 +242,7 @@
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
                     <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
-                    <!--
-                                      <img
-                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
-                                        data-src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg"
-                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
-                                        alt="">
-                                      <noscript>
-                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg" alt="">
-                                      </noscript>
-                    -->
+
                   </div>
                   <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
                 </figure>
@@ -290,16 +252,6 @@
                 <figure>
                   <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
                     <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
-                    <!--
-                                      <img
-                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
-                                        data-src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg"
-                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
-                                        alt="Placeholder photo">
-                                      <noscript>
-                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg" alt="">
-                                      </noscript>
-                    -->
                   </div>
                   <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
                 </figure>
@@ -308,16 +260,6 @@
               <li>
                 <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
                   <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="images/150815-commencement-324-xl-min.jpg" alt="">
-                  <!--
-                                  <img
-                                    class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
-                                    data-src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg"
-                                    src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
-                                    alt="">
-                                  <noscript>
-                                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
-                                  </noscript>
-                  -->
                 </div>
               </li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -48,19 +48,19 @@
         flex: 0 0 100%; /* Make each slide fill the full width of the slideshow */
       }
 
-      .unl .dcf-slide-caption[aria-hidden="true"] {
+      .theme .dcf-slide-caption[aria-hidden="true"] {
         opacity: 0;
         pointer-events: none;
         /*   transition: opacity $timing-fade-out $easing-fade-out; */
         transition: all 250ms ease-out;
       }
-      .unl .dcf-slide-caption[aria-hidden="false"] {
+      .theme .dcf-slide-caption[aria-hidden="false"] {
         opacity: 1;
         pointer-events: auto;
         /*   transition: opacity $timing-fade-in $easing-fade-in; */
         transition: opacity 250ms ease-out;
       }
-      .unl .dcf-slide-deck {
+      .theme .dcf-slide-deck {
         --btn-b-width: 2px;
         --btn-size-x: 2.75rem;
         --btn-size-y: 2.25rem;
@@ -79,10 +79,10 @@
                 0px 0px
         );
       }
-      .unl .dcf-slide-figure > div,
-      .unl .dcf-slide-figure figcaption {
+      .theme .dcf-slide-figure > div,
+      .theme .dcf-slide-figure figcaption {
       }
-      .unl .dcf-btn-slide-caption {
+      .theme .dcf-btn-slide-caption {
         background-color:rgba(36,36,35,.75);
         border-color: transparent;
         bottom: var(--clip);
@@ -90,7 +90,7 @@
         position: absolute;
         z-index: 1;
       }
-      .unl .dcf-slide-caption {
+      .theme .dcf-slide-caption {
         background-color: rgba(36,36,35,.75);
         clip-path: polygon(100% 0px, 100% 100%, calc((var(--clip) * 2) + (var(--btn-b-width) * 2) + var(--btn-size-x)) 100%, calc((var(--clip) * 2) + (var(--btn-b-width) * 2) + var(--btn-size-x)) calc(100% - (var(--clip) * 2) - (var(--btn-b-width) * 2) - var(--btn-size-y)), 0px calc(100% - (var(--clip) * 2) - (var(--btn-b-width) * 2) - var(--btn-size-y)), 0px 0px);
         color: #fefdfa;

--- a/index.html
+++ b/index.html
@@ -197,6 +197,134 @@
         </section>
       </div>
     </div>
+
+    <h1>Slideshow Test</h1>
+    <div class="dcf-bleed dcf-wrapper dcf-pt-9 dcf-pb-9 unl-bg-lightest-gray">
+      <div class="dcf-grid dcf-mb-6">
+        <div class="dcf-col-100% dcf-col-33%-start@sm dcf-col-50%-start@lg">
+          <div class="dcf-slideshow dcf-slideshow-nojs" role="region" aria-label="slideshow" tabindex="0">
+            <ul>
+              <!-- Slide 1 -->
+              <li>
+                <figure>
+                  <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/111024-autumn-018-xl-min.jpg" alt="">
+                    <!--
+                                      <img
+                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
+                                        data-src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg"
+                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
+                                        alt="Placeholder photo">
+                                      <noscript>
+                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg" alt="">
+                                      </noscript>
+                    -->
+                  </div>
+                  <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
+                </figure>
+              </li>
+              <!-- Slide 2 -->
+              <li>
+                <figure>
+                  <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/120424-campus-097-xl-min.jpg" alt="">
+                    <!--
+                                      <img
+                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
+                                        data-src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg"
+                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
+                                        alt="Placeholder photo">
+                                      <noscript>
+                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg" alt="">
+                                      </noscript>
+                    -->
+                  </div>
+                  <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
+                </figure>
+              </li>
+              <!--Slide 3 with no figcaption-->
+              <li>
+                <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
+                  <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
+                  <!--
+                                  <img
+                                    class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
+                                    data-src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg"
+                                    src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
+                                    alt="">
+                                  <noscript>
+                                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
+                                  </noscript>
+                  -->
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="dcf-grid">
+        <div class="dcf-col-100% dcf-col-33%-start@sm dcf-col-50%-start@lg">
+          <div class="dcf-slideshow dcf-slideshow-nojs" data-fade role="region" aria-label="slideshow" tabindex="0">
+            <ul>
+              <!-- Slide 1 -->
+              <li>
+                <figure>
+                  <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/111024-autumn-018-xl-min.jpg" alt="">
+                    <!--
+                                      <img
+                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
+                                        data-src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg"
+                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
+                                        alt="">
+                                      <noscript>
+                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/111024-autumn-018-xl-min.jpg" alt="">
+                                      </noscript>
+                    -->
+                  </div>
+                  <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
+                </figure>
+              </li>
+              <!-- Slide 2 -->
+              <li>
+                <figure>
+                  <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
+                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/120424-campus-097-xl-min.jpg" alt="">
+                    <!--
+                                      <img
+                                        class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
+                                        data-src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg"
+                                        src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
+                                        alt="Placeholder photo">
+                                      <noscript>
+                                        <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/120424-campus-097-xl-min.jpg" alt="">
+                                      </noscript>
+                    -->
+                  </div>
+                  <figcaption>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <small class="dcf-txt-xs dcf-txt-nowrap">Illustration by Jane Doe</small></figcaption>
+                </figure>
+              </li>
+              <!--Slide 3 with no figcaption-->
+              <li>
+                <div class="dcf-ratio dcf-ratio-16x9 dcf-ratio-1x1@sm dcf-ratio-16x9@lg">
+                  <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.1/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
+                  <!--
+                                  <img
+                                    class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover"
+                                    data-src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg"
+                                    src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
+                                    alt="">
+                                  <noscript>
+                                    <img class="dcf-d-block dcf-ratio-child dcf-obj-fit-cover" src="wdn/templates_5.0/images/dev/170902-ne-asu-0878-xl-min.jpg" alt="">
+                                  </noscript>
+                  -->
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
     <h1>Modal Test</h1>
     <button class="dcf-btn dcf-btn-primary dcf-btn-toggle-modal" data-toggles-modal="test-modal-1" type="button" disabled>Toggle Modal 1</button>
     <div class="dcf-modal" id="test-modal-1" hidden>

--- a/index.html
+++ b/index.html
@@ -47,17 +47,7 @@
       .dcf-slideshow ul:first-child li.dcf-slide {
         flex: 0 0 100%; /* Make each slide fill the full width of the slideshow */
       }
-      /* Theme styles */
-      /*
-          .unl .dcf-btn-slide-caption[aria-expanded="false"] svg {
-            transform: rotate(0);
-            transition: transform .2s cubic-bezier(.17,.89,.32,1.27);
-          }
-          .unl .dcf-btn-slide-caption[aria-expanded="true"] svg {
-            transform: rotate(45deg);
-            transition: transform .2s cubic-bezier(.17,.89,.32,1.27);
-          }
-      */
+
       .unl .dcf-slide-caption[aria-hidden="true"] {
         opacity: 0;
         pointer-events: none;
@@ -75,17 +65,7 @@
         --btn-size-x: 2.75rem;
         --btn-size-y: 2.25rem;
         --clip: 3px;
-        /*   clip-path: polygon(100% 0px, 100% calc(100% - 2.25em - 7px), calc(100% - 5.125em - 13px) calc(100% - 2.25em - 7px), calc(100% - 5.125em - 13px) 100%, 0px 100%, 0px 0px); */
-        /*
-          clip-path: polygon(
-            100% 0px,
-            100% calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
-            calc(100% - (var(--btn-size-x) * 2) - (var(--btn-b-width) * 5) - var(--clip)) calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
-            calc(100% - (var(--btn-size-x) * 2) - (var(--btn-b-width) * 5) - var(--clip)) 100%,
-            -(var(--clip)) 100%,
-            0px 0px
-          );
-        */
+
         clip-path: polygon(
                 100% 0px,
                 100% calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip)),
@@ -101,20 +81,6 @@
       }
       .unl .dcf-slide-figure > div,
       .unl .dcf-slide-figure figcaption {
-        /*   clip-path: polygon(100% 0px, 100% 100%, calc(2.56em + 7px) 100%, calc(2.56em + 7px) calc(100% - 2.25em - 7px), 0px calc(100% - 2.25em - 7px), 0px calc(100% - 2.25em - 4px), calc(2.56em + 4px) calc(100% - 2.25em - 4px), calc(2.56em + 4px) 100%, 0 100%, 0px 0px); */
-        /*
-                  clip-path: polygon(
-                          100% 0px,
-                          100% 100%,
-                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip) - 1px) 100%,
-                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip) - 1px) calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip) + 1px),
-                          0px calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) - var(--clip) + 1px), 0px calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) + 1px),
-                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) - 1px) calc(100% - var(--btn-size-y) - (var(--btn-b-width) * 2) + 1px),
-                          calc(var(--btn-size-x) + (var(--btn-b-width) * 2) - 1px) 100%,
-                          0 100%,
-                          0px 0px
-                  );
-        */
       }
       .unl .dcf-btn-slide-caption {
         background-color:rgba(36,36,35,.75);
@@ -126,17 +92,6 @@
       }
       .unl .dcf-slide-caption {
         background-color: rgba(36,36,35,.75);
-        /*   clip-path: polygon(100% 0px, 100% 100%, calc(2.56rem + 7px) 100%, calc(2.56rem + 7px) calc(100% - 2.25rem - 7px), 0px calc(100% - 2.25rem - 7px), 0px 0px); */
-        /*
-              clip-path: polygon(
-                100% 0px,
-                100% 100%,
-                calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip)) 100%,
-                calc(var(--btn-size-x) + (var(--btn-b-width) * 2) + var(--clip)) calc(100% - var(--btn-size) - (var(--btn-p-y) * 2) - (var(--btn-b-width) * 2) - var(--clip)),
-                0px calc(100% - var(--btn-size) - (var(--btn-p-y) * 2) - (var(--btn-b-width) * 2) - var(--clip)),
-                0px 0px
-              );
-        */
         clip-path: polygon(100% 0px, 100% 100%, calc((var(--clip) * 2) + (var(--btn-b-width) * 2) + var(--btn-size-x)) 100%, calc((var(--clip) * 2) + (var(--btn-b-width) * 2) + var(--btn-size-x)) calc(100% - (var(--clip) * 2) - (var(--btn-b-width) * 2) - var(--btn-size-y)), 0px calc(100% - (var(--clip) * 2) - (var(--btn-b-width) * 2) - var(--btn-size-y)), 0px 0px);
         color: #fefdfa;
         height: 100%;
@@ -147,11 +102,11 @@
         width: 100%;
         z-index: 1;
       }
-      .dcf-btn-slide-caption[aria-expanded="false"] .unl-icon-slide-caption-open {
+      .dcf-btn-slide-caption[aria-expanded="false"] .example-icon-slide-caption-open {
         opacity: 1;
         transition: opacity 250ms ease-out 125ms;
       }
-      .dcf-btn-slide-caption[aria-expanded="true"] .unl-icon-slide-caption-open {
+      .dcf-btn-slide-caption[aria-expanded="true"] .example-icon-slide-caption-open {
         opacity: 0;
         transition: opacity 250ms ease-out;
       }
@@ -414,7 +369,7 @@
       Array.prototype.forEach.call(ctrls, (ctrl) => {
         if (ctrl.getAttribute('id') === 'previous') {
           let ctrlButton = ctrl.querySelector('button');
-          ctrlButton.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'unl-cream');
+          ctrlButton.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'dcf-inverse');
           ctrlButton.innerHTML =
                   '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">' +
                   '<path d="M21.746.064a.504.504 0 0 0-.504.008l-19 11.5a.499.499 0 0 0-.001.856l19' +
@@ -422,7 +377,7 @@
                   '</svg>';
         } else if (ctrl.getAttribute('id') === 'next') {
           let ctrlButton = ctrl.querySelector('button');
-          ctrlButton.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'unl-cream');
+          ctrlButton.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'dcf-inverse');
           ctrlButton.innerHTML =
                   '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">' +
                   '<path d="M21.759 11.577L2.786.077a.499.499 0 0 0-.759.428v23a.498.498 ' +
@@ -437,17 +392,17 @@
         if (!(typeof captionBtn === 'undefined')) {
           captionBtn.innerHTML = '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" ' +
                   'width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">' +
-                  '<path class="unl-icon-slide-caption-open" ' +
+                  '<path class="example-icon-slide-caption-open" ' +
                   'd="M1,3h19c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1C0.4,1,0,1.4,0,2C0,2.6,0.4,3,1,3z"/>' +
-                  '<path class="unl-icon-slide-caption-open" ' +
+                  '<path class="example-icon-slide-caption-open" ' +
                   'd="M1,8h15c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1C0.4,6,0,6.4,0,7C0,7.6,0.4,8,1,8z"/>' +
-                  '<path class="unl-icon-slide-caption-close-1" ' +
+                  '<path class="example-icon-slide-caption-close-1" ' +
                   'd="M1,13h22c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,12.6,0.4,13,1,13z"/>' +
-                  '<path class="unl-icon-slide-caption-close-2" ' +
+                  '<path class="example-icon-slide-caption-close-2" ' +
                   'd="M1,13h22c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,12.6,0.4,13,1,13z"/>' +
-                  '<path class="unl-icon-slide-caption-open" ' +
+                  '<path class="example-icon-slide-caption-open" ' +
                   'd="M1,18h18c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,17.6,0.4,18,1,18z"/>' +
-                  '<path class="unl-icon-slide-caption-open" ' +
+                  '<path class="example-icon-slide-caption-open" ' +
                   'd="M1,23h15c0.6,0,1-0.4,1-1c0-0.6-0.4-1-1-1H1c-0.6,0-1,0.4-1,1C0,22.6,0.4,23,1,23z"/>' +
                   '</svg>';
         }
@@ -455,13 +410,13 @@
     });
     let slideBtns = document.querySelectorAll('.dcf-btn-slide');
     Array.prototype.forEach.call(slideBtns, (slideBtn) => {
-      slideBtn.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'unl-cream');
+      slideBtn.classList.add('dcf-d-flex', 'dcf-ai-center', 'dcf-pt-4', 'dcf-pb-4', 'dcf-white'); // Changing unl-cream to dcf-inverse doesn't show the button icon
     });
     let buttons = document.querySelectorAll('.dcf-btn-slide-caption');
     Array.prototype.forEach.call(buttons, (button) => {
       let caption = button.previousElementSibling;
-      let close1 = button.querySelector('.unl-icon-slide-caption-close-1');
-      let close2 = button.querySelector('.unl-icon-slide-caption-close-2');
+      let close1 = button.querySelector('.example-icon-slide-caption-close-1');
+      let close2 = button.querySelector('.example-icon-slide-caption-close-2');
 
       caption.addEventListener('openCaption', () => {
         close1.animate(keyframesClose1, options);


### PR DESCRIPTION
Implementation of Slideshows in dcf_starter for code written in dcf.

In order to test the slideshow I had to add `dcf-slideshow.js` and `dcf-slideshow-theme.js` into `dcf_starter/node_modules/dcf/js`.

I spent a day trying to implement it only to realize that I didn't have the most updated version of 2.0 so I deleted the old branch, updated 2.0, and created this one.