### PR TITLE
(Temporarily?) remove datepicker date relative positioning & z-index

### DIFF
--- a/scss/components/_components.datepickers.scss
+++ b/scss/components/_components.datepickers.scss
@@ -43,8 +43,6 @@
 .theme .dcf-datepicker-dialog-calendar td:not(.disabled):focus,
 .theme .dcf-datepicker-dialog-calendar td:not(.disabled):active {
   box-shadow: 0 0 0 3px $gray-darker, 0 0 0 5px currentColor;
-  position: relative; // Pair with z-index to ensure that box-shadow appears above adjacent elements
-  z-index: 2; // Pair with 'position: relative' to ensure that box-shadow appears above adjacent elements
 }
 
 


### PR DESCRIPTION
`postition: relative` now causes the `box-shadow` to effectively disappear in Chrome.